### PR TITLE
Update submit00_fastqc.sh

### DIFF
--- a/scripts/submit00_fastqc.sh
+++ b/scripts/submit00_fastqc.sh
@@ -18,9 +18,10 @@ DIROUT=00_fastqc-raw
 
 mkdir -p $DIROUT
 
-for file in `find $DIRIN -type f -name "*.gz" | sort`; do 
-	fastqc -t 12 -o $DIROUT --noextract $file; 
-done
+files=$(find $DIRIN -type f -name "*.gz" | sort)
+
+fastqc -t 12 -o $DIROUT --noextract $files
+
 
 # Extract tab-separated FASTQC summary
 # python fastqc-summary -s $DIROUT > $DIROUT".txt"


### PR DESCRIPTION
Per fastqc man pages (http://manpages.ubuntu.com/manpages/trusty/man1/fastqc.1.html):

       -t --threads
              Specifies  the  number of files which can be processed simultaneously.  Each thread
              will be allocated 250MB of memory so you  shouldn't  run  more  threads  than  your
              available memory will cope with, and not more than 6 threads on a 32 bit machine

Indeed in my tests, `-t` option only speeds up computation when fastqc is given multiple files at once by allowing parallel execution, and has no effect when analyzing one file at a time.   Thus the fastqc call should be changed to accept all files simultaneously with `-t num_of_threads`, or alternatively the script should use array job submission without the `-t` option to execute simultaneously on multiple cluster nodes.  Either change would drastically speed up execution.

![fastqc_1_thread](https://user-images.githubusercontent.com/22058405/128640483-4bcd8279-228c-4597-8d09-f04bd8fa5ee8.PNG)
![fastqc_12_treads](https://user-images.githubusercontent.com/22058405/128640491-8b836763-564b-47a8-95c0-c0f9c8310708.PNG)